### PR TITLE
Fix wide form of %wtdt in reference.

### DIFF
--- a/reference/hoon/runes/wt/wtdt.md
+++ b/reference/hoon/runes/wt/wtdt.md
@@ -24,7 +24,7 @@ Twig: `[%wtdt p=twig q=twig r=twig]`
 
 ##Wide form
 
-    ?:(p q r)
+    ?.(p q r)
 
 ##Irregular form
 
@@ -37,4 +37,4 @@ None
     ~zod/try=> ?.(?=(%a 'a') %not-a %yup)
     %yup
 
-Here we see two common cases of `?:` in the wide form, one uses an expression `gte` that produces a loobean and the other [`?=`]() to produce one of its cases. 
+Here we see two common cases of `?.` in the wide form, one uses an expression `gth` that produces a loobean and the other [`?=`]() to produce one of its cases. 


### PR DESCRIPTION
Fixes up the references to the example too.
