### PR TITLE
Update uses of wyt:{in,by}.

### DIFF
--- a/reference/hoon/library/2dA.md
+++ b/reference/hoon/library/2dA.md
@@ -442,7 +442,6 @@ Set size
 
 ```
   +-  wyt                                               ::  size of set
-    .+
     |-  ^-  @
     ?~(a 0 +((add $(a l.a) $(a r.a))))
 ```
@@ -451,12 +450,12 @@ Produce the number of elements in set `a` as an atom.
 
 `a` is an [set]().
 
-    ~zod/try=> =a (~(gas in `(set ,@t)`~) `(list ,@t)`[`a` `b` `c` ~])
+    ~zod/try=> =a (~(put in (~(put in (sa)) 'a')) 'b')
     ~zod/try=> ~(wyt in a)
-    4
+    2
     ~zod/try=> b
     {'bonita' 'madeleine' 'daniel' 'john'}
     ~zod/try=> ~(wyt in b)
-    5
+    4
 
 ---

--- a/reference/hoon/library/2dB.md
+++ b/reference/hoon/library/2dB.md
@@ -829,7 +829,6 @@ Depth
 
 ```
   +-  wyt                                               ::  depth of map
-    .+
     |-  ^-  @
     ?~(a 0 +((add $(a l.a) $(a r.a))))
 ```
@@ -843,10 +842,10 @@ Produce the depth of the tree map `a`.
     ~zod/try=> o
     {[p='d' q=4] [p='c' q=3]}
     ~zod/try=> ~(wyt by m)
-    3
+    2
     ~zod/try=> ~(wyt by o)
-    3
+    2
     ~zod/try=> ~(wyt by (~(uni by m) o))
-    5
+    4
 
 ---


### PR DESCRIPTION
Empty sets and maps now have size zero.
